### PR TITLE
Filter out past days from multi-day calendar events

### DIFF
--- a/app/src/main/java/ovh/litapp/neurhome3/ui/components/Calendar.kt
+++ b/app/src/main/java/ovh/litapp/neurhome3/ui/components/Calendar.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import ovh.litapp.neurhome3.data.models.Event
 import ovh.litapp.neurhome3.ui.home.CalendarUIState
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 private const val INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000L
@@ -72,7 +73,10 @@ fun Calendar(
         Box(modifier = modifier, contentAlignment = Alignment.Center) {
             if (calendarUIState.showCalendar) {
                 val sortedEvents = remember(calendarUIState.events) {
-                    calendarUIState.events.groupBy { it.dtStart.toLocalDate() }
+                    val today = LocalDate.now()
+                    calendarUIState.events
+                        .filter { !it.dtStart.toLocalDate().isBefore(today) }
+                        .groupBy { it.dtStart.toLocalDate() }
                         .toSortedMap()
                         .flatMap { (_, events) ->
                             events.sortedWith(


### PR DESCRIPTION
This commit resolves a calendar rendering bug where past days of a multi-day event were shown. It filters `calendarUIState.events` inside the `Calendar` Compose component to only include events occurring today (`LocalDate.now()`) or in the future.

---
*PR created automatically by Jules for task [1017974215928600564](https://jules.google.com/task/1017974215928600564) started by @carlo-colombo*