### PR TITLE
Use Gradle Wrapper in CI Build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Assemble APK
         run: |
-              gradle \
+              ./gradlew \
                 -Pandroid.versionName=${{steps.bump_and_tag.outputs.new_tag}} \
                 assembleProdRelease
 


### PR DESCRIPTION
Updates the Build workflow to invoke `./gradlew` rather than the system-wide `gradle` command to avoid build failures due to incompatible AGP/Gradle versions.

---
*PR created automatically by Jules for task [10883055505598033376](https://jules.google.com/task/10883055505598033376) started by @carlo-colombo*