### PR TITLE
Revert collectAsStateWithLifecycle to collectAsState

### DIFF
--- a/app/src/main/java/ovh/litapp/neurhome3/ui/applications/AllApplicationsScreen.kt
+++ b/app/src/main/java/ovh/litapp/neurhome3/ui/applications/AllApplicationsScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import ovh.litapp.neurhome3.Navigator
@@ -24,7 +24,7 @@ fun AllApplicationsScreen(
     navController: NavController,
     viewModel: AllApplicationsViewModel = viewModel(factory = AppViewModelProvider.Factory),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsState()
     Log.d(TAG, "$uiState")
 
     Column {

--- a/app/src/main/java/ovh/litapp/neurhome3/ui/home/HomeScreen.kt
+++ b/app/src/main/java/ovh/litapp/neurhome3/ui/home/HomeScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -38,7 +38,7 @@ fun HomeScreen(
     navController: NavController,
     viewModel: HomeViewModel = viewModel(factory = AppViewModelProvider.Factory),
 ) {
-    val newHomeUIState by viewModel.homeUIState.collectAsStateWithLifecycle()
+    val newHomeUIState by viewModel.homeUIState.collectAsState()
 
     Home(
         navController = navController,

--- a/app/src/main/java/ovh/litapp/neurhome3/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ovh/litapp/neurhome3/ui/settings/SettingsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -42,7 +42,7 @@ fun SettingsScreen(
     restart: (Uri?) -> Unit,
     viewModel: SettingsViewModel = viewModel(factory = AppViewModelProvider.Factory),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     Column(
         Modifier

--- a/app/src/main/java/ovh/litapp/neurhome3/ui/stats/AppStatisticsScreen.kt
+++ b/app/src/main/java/ovh/litapp/neurhome3/ui/stats/AppStatisticsScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
@@ -48,7 +48,7 @@ import java.time.format.DateTimeFormatter
 fun AppStatisticsScreen(
     viewModel: AppStatisticsViewModel = viewModel(factory = AppViewModelProvider.Factory)
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsState()
 
     Column(modifier = Modifier.padding(16.dp)) {
         Text(


### PR DESCRIPTION
Reverted the use of collectAsStateWithLifecycle() to collectAsState() across all compose screens (SettingsScreen, HomeScreen, AppStatisticsScreen, AllApplicationsScreen) to keep the app more responsive as requested.

---
*PR created automatically by Jules for task [9622271177771440443](https://jules.google.com/task/9622271177771440443) started by @carlo-colombo*